### PR TITLE
Add line color hue shift speed

### DIFF
--- a/script.js
+++ b/script.js
@@ -53,6 +53,7 @@ const options = {
     shadowblur: {letter: "𐤎", description: "size of blurry shadow applied to line segments (non-zero values might not play well with some blend modes) <i>in pixels</i>", min: 0, max: 50, step: 0.1, default: 0},
     linecap: {letter: "𐤂", description: "line cap (1: butt, 2: round, 3: squre)", min: 1, max: 3, step: 1, default: 1},
     fadeinspeed: {letter: "𐤁", description: "rate at which line segments randomly appear <i>in iterations</i>", min: 0, max: 200, step: 1, default: 0},
+    hueshiftspeed: {letter:"𐡌", description: "hue shift speed <i>in degrees per iteration</i>", min: -10, max: 10, step: 0.1, default: 0},
 
     // See note above when adding more.
 };
@@ -78,7 +79,7 @@ const optionSections = {
     "movement": ["translationhori", "translationverti"],
     "waviness": ["jitter", "wavinessphori", "wavinessahori", "wavinesspverti", "wavinessaverti"],
     "fade": ["revealspeed", "fadeinspeed", "fadeoutspeed", "fadeoutstart", "sawtoothfadeoutsize", "sawtoothfadeoutstart"],
-    "line": ["segments", "skipchance", "thickness", "linecap", "linered", "linegreen", "lineblue", "lineopacity", "blendmode", "shadowblur"],
+    "line": ["segments", "skipchance", "thickness", "linecap", "linered", "linegreen", "lineblue", "lineopacity", "hueshiftspeed", "blendmode", "shadowblur"],
     "canvas": ["width", "height", "canvasred", "canvasgreen", "canvasblue", "canvasopacity", "canvasnoise"],
 };
 
@@ -494,6 +495,116 @@ function rotate(o, p, angle) {
     return p;
 }
 
+// changeHue adapted from here https://stackoverflow.com/a/17433060
+function changeHue(rgb, degree) {
+    var hsl = rgbToHSL(rgb);
+    hsl.h += degree;
+    if (hsl.h > 360) {
+        hsl.h -= 360;
+    }
+    else if (hsl.h < 0) {
+        hsl.h += 360;
+    }
+    return hslToRGB(hsl);
+}
+
+function rgbToHSL(rgb) {
+    var r = rgb.linered / 255,
+        g = rgb.linegreen / 255,
+        b = rgb.lineblue / 255,
+        cMax = Math.max(r, g, b),
+        cMin = Math.min(r, g, b),
+        delta = cMax - cMin,
+        l = (cMax + cMin) / 2,
+        h = 0,
+        s = 0;
+
+    if (delta == 0) {
+        h = 0;
+    }
+    else if (cMax == r) {
+        h = 60 * (((g - b) / delta) % 6);
+    }
+    else if (cMax == g) {
+        h = 60 * (((b - r) / delta) + 2);
+    }
+    else {
+        h = 60 * (((r - g) / delta) + 4);
+    }
+
+    if (delta == 0) {
+        s = 0;
+    }
+    else {
+        s = (delta/(1-Math.abs(2*l - 1)))
+    }
+
+    return {
+        h: h,
+        s: s,
+        l: l
+    }
+}
+
+function hslToRGB(hsl) {
+    var h = hsl.h,
+        s = hsl.s,
+        l = hsl.l,
+        c = (1 - Math.abs(2*l - 1)) * s,
+        x = c * ( 1 - Math.abs((h / 60 ) % 2 - 1 )),
+        m = l - c/ 2,
+        r, g, b;
+
+    if (h < 60) {
+        r = c;
+        g = x;
+        b = 0;
+    }
+    else if (h < 120) {
+        r = x;
+        g = c;
+        b = 0;
+    }
+    else if (h < 180) {
+        r = 0;
+        g = c;
+        b = x;
+    }
+    else if (h < 240) {
+        r = 0;
+        g = x;
+        b = c;
+    }
+    else if (h < 300) {
+        r = x;
+        g = 0;
+        b = c;
+    }
+    else {
+        r = c;
+        g = 0;
+        b = x;
+    }
+
+    r = normalize_rgb_value(r, m);
+    g = normalize_rgb_value(g, m);
+    b = normalize_rgb_value(b, m);
+
+    return {
+        linered: r,
+        linegreen: g,
+        lineblue: b
+    }
+}
+
+function normalize_rgb_value(color, m) {
+    color = Math.floor((color + m) * 255);
+    if (color < 0) {
+        color = 0;
+    }
+    return color;
+}
+
 const canvas = document.getElementsByTagName("canvas")[0];
 const ctx = canvas.getContext("2d");
 let inter = null;
@@ -641,6 +752,12 @@ function restartRendering(opts) {
             iterationsMeter.style.width = "0";
         }
 
+        if (opts.hueshiftspeed != 0) {
+            var strokeColor = changeHue(opts, (opts.hueshiftspeed * n) % 360);
+            // setup line drawing settings
+            ctx.strokeStyle = `rgba(${strokeColor.linered},${strokeColor.linegreen},${strokeColor.lineblue},${opts.lineopacity})`;
+        }
+        
         ctx.beginPath();
 
         line = line.map((p, i) => {


### PR DESCRIPTION
Added an option to dynamically change the hue of the line color.

Example of what can be done: https://i.imgur.com/18sMupc.png
Config for that example: `#r580ro-0.9rot0.41rota0.59e0.995ex0.996t0.7se6700sk0.04i2000w1200h1200c10ca15can18l255li142lin78line0.49b6f788rotat822wa8508wav3015wavi1.3j0.3linec2hu0.42`

Comments:
- new `hueshiftspeed` option added at the bottom (following the guidelines)
- option ranges (-10 to 10, step 0.1) chosen by eyeballing
- `changeHue` function adapted from here https://stackoverflow.com/a/17433060
- `changeHue` and auxiliary functions added bellow other auxiliary functions, between `rotate` and `restartRendering`
- letter for the UI slider (ܘ) chosen at random from the (unused ones of the) [Aramaic alfabet](https://en.wikipedia.org/wiki/Aramaic_alphabet)
- performance wise, when `hueshiftspeed != 0` it would be better to store the initial color value as HSL to avoid the RGB->HSL conversion each step. Or even avoiding RGB and specifying the value as `hsla(...)`. I didn't see it worth the effort.
